### PR TITLE
draft of update command 

### DIFF
--- a/datalad_xnat/__init__.py
+++ b/datalad_xnat/__init__.py
@@ -1,18 +1,18 @@
 command_suite = (
     'XNAT server access support',
     [
-#        (
-#            'datalad_xnat.init',
-#            'Init',
-#            'xnat-init',
-#            'xnat_init',
-#        ),
-#        (
-#            'datalad_xnat.update',
-#            'Update',
-#            'xnat-update',
-#            'xnat_update',
-#        ),
+        (
+            'datalad_xnat.init',
+            'Init',
+            'xnat-init',
+            'xnat_init',
+        ),
+        (
+            'datalad_xnat.update',
+            'Update',
+            'xnat-update',
+            'xnat_update',
+        ),
     ]
 )
 

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -155,8 +155,8 @@ class Init(Interface):
             return
 
         # put essential configuration into the dataset
-        config.set('datalad.xnat.default.url',url,where='dataset')
-        config.set('datalad.xnat.default.project',project,where='dataset')
+        config.set('datalad.xnat.default.url', url, where='dataset')
+        config.set('datalad.xnat.default.project', project, where='dataset')
 
         ds.save(
             path='.datalad/config',

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -159,7 +159,7 @@ class Init(Interface):
         config.set('datalad.xnat.default.project', project, where='dataset')
 
         ds.save(
-            path='.datalad/config',
+            path=ds.pathobj / '.datalad' / 'config',
             to_git=True,
             message="Configure default XNAT url and project",
         )

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -31,7 +31,7 @@ from datalad.distribution.dataset import (
     require_dataset,
 )
 from datalad.downloaders.credentials import UserPassword
-
+from urllib.parse import urlparse
 
 __docformat__ = 'restructuredtext'
 
@@ -89,10 +89,12 @@ class Init(Interface):
             refds=ds.path,
         )
 
-        # obtain user credentials, use provided URL as identifier
+        # obtain user credentials, use simplified/stripped URL as identifier
         # given we don't have more knowledge than the user, do not
         # give a `url` to provide hints on how to obtain credentials
-        cred = UserPassword(name=url, url=None)()
+        parsed_url = urlparse(url)
+        no_proto_url='{}{}'.format(parsed_url.netloc, parsed_url.path).replace(' ', '')
+        cred = UserPassword(name=no_proto_url, url=None)()
 
         xn = XNATInterface(server=url, **cred)
 

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -144,9 +144,20 @@ class Init(Interface):
                  nsubj, project)
 
         # put essential configuration into the dataset
-        config.set('datalad.
+        config.set('datalad.xnat.default.url',url,where='dataset')
+        config.set('datalad.xnat.default.project',project,where='dataset')
+
+        ds.save(
+            path='.datalad/config',
+            to_git=True,
+            message="Configure default XNAT url and project",
+        )
+
+        # Configure XNAT access authentication
+        ds.run_procedure(spec='cfg_xnat_dataset')
 
         yield dict(
             res,
             status='ok',
         )
+        return

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -143,6 +143,17 @@ class Init(Interface):
         lgr.info('XNAT reports %i subjects currently on-record for project %s',
                  nsubj, project)
 
+        # check if dataset already initialized
+        auth_dir = ds.pathobj / '.datalad' / 'providers'
+        if auth_dir.exists() and not force:
+            yield dict(
+                res,
+                status='error',
+                message='Dataset found already initialized, '
+                        'use `force` to reinitialize',
+            )
+            return
+
         # put essential configuration into the dataset
         config.set('datalad.xnat.default.url',url,where='dataset')
         config.set('datalad.xnat.default.project',project,where='dataset')

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -117,7 +117,7 @@ class Init(Interface):
             projects = xn.select.projects().get()
             ui.message(
                 'No project name specified. The following projects are '
-                'available on {}:'.format(url))
+                'available on {} for user {}:'.format(url, cred['user']))
             for p in sorted(projects):
                 # list and prep for C&P
                 # TODO multi-column formatting?

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -155,7 +155,7 @@ class Init(Interface):
             return
 
         # put essential configuration into the dataset
-        config.set('datalad.xnat.default.url', url, where='dataset')
+        config.set('datalad.xnat.default.url', url, where='dataset', reload=False)
         config.set('datalad.xnat.default.project', project, where='dataset')
 
         ds.save(

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -1,0 +1,76 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+
+import logging
+import csv
+from datalad.utils import quote_cmdlinearg
+
+lgr = logging.getLogger('datalad.xnat.parse')
+
+
+def parse_xnat(ds, subs, force, xn, xnat_url, xnat_project):
+    """Lookup specified subject(s) for configured XNAT project and build csv table.
+
+    Parameters
+    ----------
+    ds: Dataset
+    subs: str
+        The subjects to build a csv table for.
+    force: str
+        Re-build csv table if it already exists.
+    xn: str
+        XNAT instance
+    xnat_url: str
+    xnat_project: str
+    """
+
+    # prep for yield
+    res = dict(
+        action='xnat_parse',
+        type='file',
+        logger=lgr,
+        refds=ds.path,
+    )
+
+    # create csv table for each subject containing subject info & file urls
+    table_header = ['subject', 'experiment', 'scan', 'resource', 'filename', 'url']
+    for sub in subs:
+        csv_path = f"addurl_files/{sub}_table.csv"
+        sub_table = ds.pathobj / '{}'.format(csv_path)
+
+        # check if table already exists
+        if sub_table.exists() and not force:
+            lgr.info('%s already exists. To query latest subject info, use `force`.', csv_path)
+            continue
+            #TODO: provide more info about existing file
+        elif sub_table.exists() and force:
+            sub_table.unlink()
+
+        sub_table.parent.mkdir(parents=True, exist_ok=True)
+
+        # write subject info to file
+        with open(sub_table, 'w') as outfile:
+            fh = csv.writer(outfile, delimiter=',')
+            fh.writerow(table_header)
+
+            lgr.info('Querying info for subject %s', sub)
+            xnsub = xn.select.project(xnat_project).subject(sub)
+            for experiment in xnsub.experiments().get():
+                for scan in xnsub.experiment(experiment).scans().get():
+                    for resource in xnsub.experiment(experiment).scan(scan).resources().get():
+                        for filename in xnsub.experiment(experiment).scan(scan).resource(resource).files().get():
+                            url = f"{xnat_url}/data/projects/{xnat_project}/subjects/{sub}/experiments/{experiment}/scans/{scan}/resources/{resource}/files/{filename}"
+                            # create line for each file with necessary subject info
+                            fh.writerow([sub, experiment, scan, resource, filename, url])
+    yield dict(
+        res,
+        status='ok',
+    )

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -16,14 +16,14 @@ from datalad.utils import quote_cmdlinearg
 lgr = logging.getLogger('datalad.xnat.parse')
 
 
-def parse_xnat(ds, subs, force, xn, xnat_url, xnat_project):
-    """Lookup specified subject(s) for configured XNAT project and build csv table.
+def parse_xnat(ds, sub, force, xn, xnat_url, xnat_project):
+    """Lookup specified subject for configured XNAT project and build csv table.
 
     Parameters
     ----------
     ds: Dataset
-    subs: str
-        The subjects to build a csv table for.
+    sub: str
+        The subject to build a csv table for.
     force: str
         Re-build csv table if it already exists.
     xn: str
@@ -40,36 +40,35 @@ def parse_xnat(ds, subs, force, xn, xnat_url, xnat_project):
         refds=ds.path,
     )
 
-    # create csv table for each subject containing subject info & file urls
-    table_header = ['subject', 'experiment', 'scan', 'resource', 'filename', 'url']
-    for sub in subs:
-        csv_path = f"addurl_files/{sub}_table.csv"
-        sub_table = ds.pathobj / '{}'.format(csv_path)
+    # create csv table containing subject info & file urls
+    table_header = ['subject', 'session', 'scan', 'resource', 'filename', 'url']
+    csv_path = f"addurl_files/{sub}_table.csv"
+    sub_table = ds.pathobj / '{}'.format(csv_path)
 
-        # check if table already exists
-        if sub_table.exists() and not force:
-            lgr.info('%s already exists. To query latest subject info, use `force`.', csv_path)
-            continue
-            #TODO: provide more info about existing file
-        elif sub_table.exists() and force:
-            sub_table.unlink()
+    # check if table already exists
+    if sub_table.exists() and not force:
+        lgr.info('%s already exists. To query latest subject info, use `force`.', csv_path)
+        return
+        #TODO: provide more info about existing file
+    elif sub_table.exists() and force:
+        sub_table.unlink()
 
-        sub_table.parent.mkdir(parents=True, exist_ok=True)
+    sub_table.parent.mkdir(parents=True, exist_ok=True)
 
-        # write subject info to file
-        with open(sub_table, 'w') as outfile:
-            fh = csv.writer(outfile, delimiter=',')
-            fh.writerow(table_header)
+    # write subject info to file
+    with open(sub_table, 'w') as outfile:
+        fh = csv.writer(outfile, delimiter=',')
+        fh.writerow(table_header)
 
-            lgr.info('Querying info for subject %s', sub)
-            xnsub = xn.select.project(xnat_project).subject(sub)
-            for experiment in xnsub.experiments().get():
-                for scan in xnsub.experiment(experiment).scans().get():
-                    for resource in xnsub.experiment(experiment).scan(scan).resources().get():
-                        for filename in xnsub.experiment(experiment).scan(scan).resource(resource).files().get():
-                            url = f"{xnat_url}/data/projects/{xnat_project}/subjects/{sub}/experiments/{experiment}/scans/{scan}/resources/{resource}/files/{filename}"
-                            # create line for each file with necessary subject info
-                            fh.writerow([sub, experiment, scan, resource, filename, url])
+        lgr.info('Querying info for subject %s', sub)
+        xnsub = xn.select.project(xnat_project).subject(sub)
+        for experiment in xnsub.experiments().get():
+            for scan in xnsub.experiment(experiment).scans().get():
+                for resource in xnsub.experiment(experiment).scan(scan).resources().get():
+                    for filename in xnsub.experiment(experiment).scan(scan).resource(resource).files().get():
+                        url = f"{xnat_url}/data/projects/{xnat_project}/subjects/{sub}/experiments/{experiment}/scans/{scan}/resources/{resource}/files/{filename}"
+                        # create line for each file with necessary subject info
+                        fh.writerow([sub, experiment, scan, resource, filename, url])
     yield dict(
         res,
         status='ok',

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -69,6 +69,13 @@ def parse_xnat(ds, sub, force, xn, xnat_url, xnat_project):
                         url = f"{xnat_url}/data/projects/{xnat_project}/subjects/{sub}/experiments/{experiment}/scans/{scan}/resources/{resource}/files/{filename}"
                         # create line for each file with necessary subject info
                         fh.writerow([sub, experiment, scan, resource, filename, url])
+
+    ds.save(
+        path=sub_table,
+        message=f"Add file url table for {sub}",
+        to_git=True
+        )
+
     yield dict(
         res,
         status='ok',

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -42,7 +42,7 @@ def parse_xnat(ds, sub, force, xn, xnat_url, xnat_project):
 
     # create csv table containing subject info & file urls
     table_header = ['subject', 'session', 'scan', 'resource', 'filename', 'url']
-    csv_path = f"addurl_files/{sub}_table.csv"
+    csv_path = f"code/addurl_files/{sub}_table.csv"
     sub_table = ds.pathobj / '{}'.format(csv_path)
 
     # check if table already exists

--- a/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
+++ b/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
@@ -46,6 +46,9 @@ import sys
 
 from datalad.api import Dataset
 from urllib.parse import urlparse
+from datalad.support.annexrepo import AnnexRepo
+from datalad.consts import DATALAD_SPECIAL_REMOTE
+from datalad.support.exceptions import (RemoteNotAvailableError)
 
 ds = Dataset(sys.argv[1])
 
@@ -99,3 +102,12 @@ ds.save(
     to_git=True,
     message="Configure XNAT access authentication",
 )
+
+# enable datalad special remote
+annex = AnnexRepo(ds.path)
+try:
+    annex.is_special_annex_remote(DATALAD_SPECIAL_REMOTE)
+except RemoteNotAvailableError:
+    annex.init_remote(DATALAD_SPECIAL_REMOTE,
+        ['encryption=none', 'type=external', 'externaltype=%s' % DATALAD_SPECIAL_REMOTE,
+            'autoenable=true'])

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -15,6 +15,7 @@ import csv
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
 from datalad.support.constraints import (
     EnsureStr,
     EnsureNone,
@@ -85,6 +86,17 @@ class Update(Interface):
             dataset, check_installed=True, purpose='update')
 
         subjects = ensure_list(subjects)
+
+        # require a clean dataset
+        if ds.repo.dirty:
+            yield get_status_dict(
+                'update',
+                ds=ds,
+                status='impossible',
+                message=(
+                    'clean dataset required to detect changes from command; '
+                    'use `datalad status` to inspect unsaved changes'))
+            return
 
         # prep for yield
         res = dict(
@@ -165,9 +177,6 @@ class Update(Interface):
                 cfg_proc='xnat_dataset',
                 result_renderer='default',
             )
-
-            # add the csv table to git
-            ds.repo.add(table, git=True)
 
             ds.save(
                 message=f"Update files for subject {sub}",

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -166,6 +166,9 @@ class Update(Interface):
                 result_renderer='default',
             )
 
+            # add the csv table to git
+            ds.repo.add(table, git=True)
+
             ds.save(
                 message=f"Update files for subject {sub}",
                 recursive=True

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -78,7 +78,7 @@ class Update(Interface):
     @staticmethod
     @datasetmethod(name='xnat_update')
     @eval_results
-    def __call__(subjects, dataset=None, ifexists=None, force=False):
+    def __call__(subjects='list', dataset=None, ifexists=None, force=False):
         from pyxnat import Interface as XNATInterface
 
         ds = require_dataset(
@@ -116,6 +116,9 @@ class Update(Interface):
                 'project {}:'.format(xnat_project))
             for s in sorted(subs):
                 ui.message(" {}".format(quote_cmdlinearg(s)))
+            ui.message(
+                'Specify a specific subject(s) or "all" to download associated '
+                'files for.')
             return
 
         # query the specified subject(s) to make sure it exists and is accessible

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -94,8 +94,8 @@ class Update(Interface):
                 ds=ds,
                 status='impossible',
                 message=(
-                    'clean dataset required to detect changes from command; '
-                    'use `datalad status` to inspect unsaved changes'))
+                    'Clean dataset required; use `datalad status` to inspect '
+                    'unsaved changes'))
             return
 
         # prep for yield

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -143,7 +143,7 @@ class Update(Interface):
 
         # create csv table for each subject that contains subject info &
         # urls for each file
-        table_header = ['subject','experiment','scan','resource','filename','url',]
+        table_header = ['subject', 'experiment', 'scan', 'resource', 'filename', 'url']
         for subject in subjects:
             csv_path = f"addurl_files/{subject}_table.csv"
             sub_table = ds.pathobj / '{}'.format(csv_path)

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -1,0 +1,187 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+"""
+
+import logging
+import csv
+
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.interface.base import build_doc
+from datalad.interface.add_archive_content import AddArchiveContent
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureNone,
+)
+from datalad.support.param import Parameter
+from datalad.support.exceptions import CommandError
+from datalad.utils import (
+    ensure_list,
+    quote_cmdlinearg,
+)
+
+from datalad.distribution.dataset import (
+    datasetmethod,
+    EnsureDataset,
+    require_dataset,
+)
+
+from datalad.downloaders.credentials import UserPassword
+
+__docformat__ = 'restructuredtext'
+
+lgr = logging.getLogger('datalad.xnat.update')
+
+
+@build_doc
+class Update(Interface):
+    """Lookup subjects for configured XNAT project and build csv tables for each
+    subject that can be fed to datalad addurls.
+
+    This command expects an xnat-init initialized DataLad dataset.
+    """
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            metavar='DATASET',
+            doc="""specify the dataset to perform the initialization on""",
+            constraints=EnsureDataset() | EnsureNone()
+        ),
+        subject=Parameter(
+            args=("-s", "--subject"),
+            doc="""Specify the subject for whom to build a csv table.
+            'list': list existing subjects,
+            'all': create a table for all existing subjects""",
+        ),
+    )
+    @staticmethod
+    @datasetmethod(name='xnat_update')
+    @eval_results
+    def __call__(dataset=None, subject=None):
+        from pyxnat import Interface as XNATInterface
+
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='update')
+
+        # prep for yield
+        res = dict(
+            action='xnat_update',
+            path=ds.path,
+            type='dataset',
+            logger=lgr,
+            refds=ds.path,
+        )
+
+        # obtain configured XNAT url and project name
+        xnat_cfg_name = ds.config.get('datalad.xnat.default-name', 'default')
+        cfg_section = 'datalad.xnat.{}'.format(xnat_cfg_name)
+        xnat_url = ds.config.obtain(
+                '{}.url'.format(cfg_section),
+                dialog_type='question',
+                title='XNAT server address',
+                text='Full URL of XNAT server (e.g. https://xnat.example.com:8443/xnat)',
+                store=False,
+                reload=False)
+
+        xnat_project = ds.config.obtain(
+                '{}.project'.format(cfg_section),
+                dialog_type='question',
+                title='XNAT project',
+                text='Project on XNAT server',
+                store=False,
+                reload=False)
+
+        # obtain user credentials
+        cred = UserPassword(name=xnat_url, url=None)()
+        xn = XNATInterface(server=xnat_url, **cred)
+
+        if subject is None:
+            from datalad.ui import ui
+            # get list of all subjects
+            subjects = xn.select.project(xnat_project).subjects().get()
+            ui.message(
+                    'No subject specified. The following subjects are available '
+                    'for XNAT project {}:'.format(xnat_project))
+            for s in sorted(subjects):
+                ui.message(" {}".format(quote_cmdlinearg(s)))
+            return
+
+        # provide subject list
+        if subject == 'list':
+            from datalad.ui import ui
+            subjects = xn.select.project(xnat_project).subjects().get()
+            ui.message(
+                    'The following subjects are available for XNAT '
+                    'project {}:'.format(xnat_project))
+            for s in sorted(subjects):
+                ui.message(" {}".format(quote_cmdlinearg(s)))
+            return
+
+        # query the specified subject to make sure it exists and is accessible
+        if subject != 'all':
+            from datalad.ui import ui
+            sub = xn.select.project(xnat_project).subject(subject)
+            nexp = len(sub.experiments().get())
+            if nexp > 0:
+                subjects = [subject]
+            else:
+                ui.message(
+                    'Failed to obtain information on subject {} from XNAT '
+                    'project {}:'.format(subject, xnat_project))
+                return
+        else:
+            # if all, get list of all subjects
+            subjects = xn.select.project(xnat_project).subjects().get()
+
+        # create csv table for each subject that contains subject info &
+        # urls for each file
+        table_header = ['subject','experiment','scan','resource','filename','url',]
+        for subject in subjects:
+            csv_path = f"addurl_files/{subject}_table.csv"
+            sub_table = ds.pathobj / '{}'.format(csv_path)
+
+            # check if table already exists
+            if sub_table.exists():
+                lgr.info('%s already exists', csv_path)
+                #TODO: provide more info about existing file
+                sub_table.unlink()
+
+            sub_table.parent.mkdir(parents=True, exist_ok=True)
+
+            # write subject info to file
+            with open(sub_table, 'w') as outfile:
+                fh = csv.writer(outfile, delimiter=',')
+                fh.writerow(table_header)
+
+                lgr.info('Querying info for subject %s', subject)
+                xnsub = xn.select.project(xnat_project).subject(subject)
+                for experiment in xnsub.experiments().get():
+                    for scan in xnsub.experiment(experiment).scans().get():
+                        for resource in xnsub.experiment(experiment).scan(scan).resources().get():
+                            for filename in xnsub.experiment(experiment).scan(scan).resource(resource).files().get():
+                                url = f"{xnat_url}/data/projects/{xnat_project}/subjects/{subject}/experiments/{experiment}/scans/{scan}/resources/{resource}/files/{filename}"
+                                # create line for each file with necessary subject info
+                                fh.writerow([subject, experiment, scan, resource, filename, url])
+
+            # save current file
+            ds.save(
+                str(sub_table),
+                to_git=True,
+                message=f"Update XNAT info for subject {subject}"
+            )
+
+            lgr.info('%s created', csv_path)
+
+        yield dict(
+            res,
+            status='ok'
+        )
+        return

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -141,7 +141,7 @@ class Update(Interface):
 
         # parse and download one subject at a time
         from datalad_xnat.parser import parse_xnat
-        addurl_dir = ds.pathobj / 'addurl_files'
+        addurl_dir = ds.pathobj / 'code' / 'addurl_files'
         for sub in subs:
             yield from parse_xnat(
                 ds,

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -104,21 +104,8 @@ class Update(Interface):
         # obtain configured XNAT url and project name
         xnat_cfg_name = ds.config.get('datalad.xnat.default-name', 'default')
         cfg_section = 'datalad.xnat.{}'.format(xnat_cfg_name)
-        xnat_url = ds.config.obtain(
-            '{}.url'.format(cfg_section),
-            dialog_type='question',
-            title='XNAT server address',
-            text='Full URL of XNAT server (e.g. https://xnat.example.com:8443/xnat)',
-            store=False,
-            reload=False)
-
-        xnat_project = ds.config.obtain(
-            '{}.project'.format(cfg_section),
-            dialog_type='question',
-            title='XNAT project',
-            text='Project on XNAT server',
-            store=False,
-            reload=False)
+        xnat_url = ds.config.get('{}.url'.format(cfg_section))
+        xnat_project = ds.config.get('{}.project'.format(cfg_section))
 
         # obtain user credentials
         cred = UserPassword(name=xnat_url, url=None)()

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -35,6 +35,7 @@ from datalad.distribution.dataset import (
 )
 
 from datalad.downloaders.credentials import UserPassword
+from urllib.parse import urlparse
 
 #import datalad.plugin.addurls
 
@@ -111,7 +112,9 @@ class Update(Interface):
         xnat_project = ds.config.get('{}.project'.format(cfg_section))
 
         # obtain user credentials
-        cred = UserPassword(name=xnat_url, url=None)()
+        parsed_url = urlparse(xnat_url)
+        no_proto_url='{}{}'.format(parsed_url.netloc, parsed_url.path).replace(' ', '')
+        cred = UserPassword(name=no_proto_url, url=None)()
         xn = XNATInterface(server=xnat_url, **cred)
 
         # provide subject list


### PR DESCRIPTION
@mih I've made `init` functional and have the beginnings for `update`. There are a few aspects/implementation details that I'm uncertain about, and will leave some notes here. 

* I chose not to hook `update` into `addurls`. I don't see how we can anticipate all the possible ways people will want to structure their dataset (subdatasets, directories, etc) with the varying number of subjects, acquisitions, and files that a given project will have. I thought it might make more sense to stay simple and just do a lookup of subject info and then build csv tables that can be fed directly to `addurls` in a separate command line call. If people need to modify the default structure, they can easily do so before running `addurls`.

* I don't think the name "update" is a good fit for the current functionality of the command. However, I struggled to come up with a better idea. ;-) Plus, there's a decent possibility the functionality might change, so I'll leave that as a todo for now.

* I don't quite understand why, but `addurls` doesn't work unless I first enable the datalad special remote; even if I've run the xnat configuration that sets up the auth file. I got the idea to enable the special remote from https://github.com/datalad/datalad/issues/3610

That's about it. I'm really interested in thoughts, feedback, criticism, etc. :-)