### PR TITLE
Drop pyxnat and minimize queries

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -103,7 +103,7 @@ class Init(Interface):
 
         if project is None:
             from datalad.ui import ui
-            projects = platform.xn.select.projects().get()
+            projects = platform.get_projects()
             ui.message(
                 'No project name specified. The following projects are '
                 'available on {} for user {}:'.format(
@@ -117,10 +117,10 @@ class Init(Interface):
             return
 
         # query the specified project to make sure it exists and is accessible
-        proj = platform.xn.select.project(project)
-
         try:
-            nsubj = len(proj.subjects().get())
+            # TODO for big projects this may not be the cheapest possible query
+            # that ensures existence of the project
+            nsubj = platform.get_nsubjs(project)
         except Exception as e:
             yield dict(
                 res,

--- a/datalad_xnat/tests/test_register.py
+++ b/datalad_xnat/tests/test_register.py
@@ -1,4 +1,14 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
 
+"""
 
 def test_register():
     import datalad.api as da

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,7 @@ classifiers =
 python_requires = >= 3.5
 install_requires =
     datalad >= 0.12.3
-    pyxnat
-    # should come via pyxnat, but doesn't
-    pyOpenSSL>=0.14
+    requests
 test_requires =
     nose
     coverage


### PR DESCRIPTION
From datalad/datalad-xnat#30 we already know that pyxnat is not a full
solution. Moreover, it seems to force us to perform more queries than
strictly necessary -- slowing operations.

Here I reimplement all necessary queries in a minimalistic fashion.
This has many holes, including error handling. But it works so far,
and is indeed faster (by performing only 75% of the previous numer of
queries).

Fixes datalad/datalad-xnat#17
Fixes datalad/datalad-xnat#10
Fixes datalad/datalad-xnat#11
Fixes datalad/datalad-xnat#32