### PR TITLE
Support connectomeDB

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -108,8 +108,8 @@ class Init(Interface):
                 'No project name specified. The following projects are '
                 'available on {} for user {}:'.format(
                     url,
-                    'anonymous' if platform.cred['anonymous']
-                    else platform.cred['user']))
+                    'anonymous' if platform.credential_name == 'anonymous'
+                    else platform.authenticated_user))
             for p in sorted(projects):
                 # list and prep for C&P
                 # TODO multi-column formatting?
@@ -157,7 +157,7 @@ class Init(Interface):
             message="Configure default XNAT url and project",
         )
 
-        if not platform.cred['anonymous']:
+        if not platform.credential_name == 'anonymous':
             # Configure XNAT access authentication
             ds.run_procedure(spec='cfg_xnat_dataset')
 

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -21,7 +21,6 @@ from datalad.support.constraints import (
 from datalad.support.param import Parameter
 from datalad.utils import (
     quote_cmdlinearg,
-    with_pathsep,
 )
 
 from datalad.distribution.dataset import (
@@ -77,10 +76,16 @@ class Init(Interface):
             action='store_true'),
         **_XNAT.cmd_params
     )
+
     @staticmethod
     @datasetmethod(name='xnat_init')
     @eval_results
-    def __call__(url, path="{subject}/{session}/{scan}/", project=None, force=False, credential=None, dataset=None):
+    def __call__(url,
+                 path="{subject}/{session}/{scan}/",
+                 project=None,
+                 force=False,
+                 credential=None,
+                 dataset=None):
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='initialization')
@@ -148,9 +153,12 @@ class Init(Interface):
 
         # put essential configuration into the dataset
         # TODO https://github.com/datalad/datalad-xnat/issues/42
-        config.set('datalad.xnat.default.url', url, where='dataset', reload=False)
-        config.set('datalad.xnat.default.project', project, where='dataset', reload=False)
-        config.set('datalad.xnat.default.path', path, where='dataset', reload=False)
+        config.set('datalad.xnat.default.url',
+                   url, where='dataset', reload=False)
+        config.set('datalad.xnat.default.project',
+                   project, where='dataset', reload=False)
+        config.set('datalad.xnat.default.path',
+                   path, where='dataset', reload=False)
         config.set('datalad.xnat.default.credential-name',
                    platform.credential_name, where='dataset')
 

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -147,9 +147,12 @@ class Init(Interface):
             return
 
         # put essential configuration into the dataset
+        # TODO https://github.com/datalad/datalad-xnat/issues/42
         config.set('datalad.xnat.default.url', url, where='dataset', reload=False)
-        config.set('datalad.xnat.default.project', project, where='dataset')
-        config.set('datalad.xnat.default.path', path, where='dataset')
+        config.set('datalad.xnat.default.project', project, where='dataset', reload=False)
+        config.set('datalad.xnat.default.path', path, where='dataset', reload=False)
+        config.set('datalad.xnat.default.credential-name',
+                   platform.credential_name, where='dataset')
 
         ds.save(
             path=ds.pathobj / '.datalad' / 'config',

--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -61,7 +61,6 @@ class _XNAT(object):
             credential = urlparse(url).netloc
 
         if credential == 'anonymous':
-            cred = dict(anonymous=True, user=None, password=None)
             auth = None
         else:
             try:
@@ -77,9 +76,6 @@ class _XNAT(object):
                     f'Authorization required for {self.fullname}, '
                     f'cannot find token for a credential {credential}.') from e
 
-            cred = dict(anonymous=False,
-                        user=auth['user'] or None,
-                        password=auth['password'] or None)
             session.auth = (auth['user'], auth['password'])
 
         # now check of auth works (if any is needed)
@@ -92,9 +88,16 @@ class _XNAT(object):
             raise RuntimeError(
                 'Failed to access the XNAT server. Full error:\n%s', e) from e
 
-        # TODO make private
-        self.cred = cred
         self._session = session
+        self._credential_name = credential
+
+    @property
+    def credential_name(self):
+        return self._credential_name
+
+    @property
+    def authenticated_user(self):
+        return self._session.auth[0] if self._session else None
 
     def get_projects(self):
         """Returns a list with project identifiers"""

--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -98,19 +98,13 @@ class _XNAT(object):
 
     def get_projects(self):
         """Returns a list with project identifiers"""
-        return [
-            r['ID']
-            for r in self._unwrap(self._session.get(
-                self._get_api('projects')))
-        ]
+        return self._unwrap_ids(self._session.get(
+            self._get_api('projects')))
 
     def get_subjects(self, project):
         """Return a list of subject IDs available in a project"""
-        return [
-            r['ID']
-            for r in self._unwrap(self._session.get(
-                self._get_api('subjects', project=project)))
-        ]
+        return self._unwrap_ids(self._session.get(
+            self._get_api('subjects', project=project)))
 
     def get_nsubjs(self, project):
         """Return the number of subjects available in a project"""
@@ -118,21 +112,15 @@ class _XNAT(object):
 
     def get_experiments(self, project, subject):
         """Return a list of experiment IDs available for a project's subject"""
-        return [
-            r['ID']
-            for r in self._unwrap(self._session.get(
-                self._get_api('experiments',
-                              project=project,
-                              subject=subject)))
-        ]
+        return self._unwrap_ids(self._session.get(
+            self._get_api('experiments',
+                          project=project,
+                          subject=subject)))
 
     def get_scans(self, experiment):
         """Return a list of scan IDs available for an experiment"""
-        return [
-            r['ID']
-            for r in self._unwrap(self._session.get(
-                self._get_api('scans', experiment=experiment)))
-        ]
+        return self._unwrap_ids(self._session.get(
+            self._get_api('scans', experiment=experiment)))
 
     def get_files(self, experiment, scan):
         """Return a list of file records for a scan in an experiment"""
@@ -148,3 +136,11 @@ class _XNAT(object):
     def _unwrap(self, response):
         return response.json().get('ResultSet', {}).get('Result')
 
+    def _unwrap_ids(self, response):
+        unwrapped = self._unwrap(response)
+        # do a little dance to figure out what the ID key is
+        # normal XNAT is 'ID', but connectomeDB uses 'id'
+        # TODO is there a way to ask XNAT what it would be
+        # maybe query the schema?
+        id_attr = 'ID' if unwrapped and 'ID' in unwrapped[0] else 'id'
+        return [r[id_attr] for r in unwrapped]

--- a/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
+++ b/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
@@ -67,18 +67,17 @@ parsed_url = urlparse(xnat_url)
 auth_cfg = """\
 [provider:xnat-{name}]
 url_re = {url}/.*
-credential = {no_proto_url}
+credential = {credential_name}
 authentication_type = {auth_type}
 
-[credential:{no_proto_url}]
+[credential:{credential_name}]
 type = {cred_type}
 """.format(
     name=xnat_cfg_name,
     # strip /, because it is in the template
     url=xnat_url.rstrip('/'),
     # use a simplified/stripped URL as identifier for the credential cfg
-    no_proto_url='{}{}'.format(
-        parsed_url.netloc, parsed_url.path).replace(' ', ''),
+    credential_name=ds.config.obtain('{}.credential-name'.format(cfg_section)),
     auth_type=ds.config.obtain(
         '{}.authentication-type'.format(cfg_section),
         'http_basic_auth'),

--- a/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
+++ b/datalad_xnat/resources/procedures/cfg_xnat_dataset.py
@@ -74,7 +74,8 @@ authentication_type = {auth_type}
 type = {cred_type}
 """.format(
     name=xnat_cfg_name,
-    url=xnat_url,
+    # strip /, because it is in the template
+    url=xnat_url.rstrip('/'),
     # use a simplified/stripped URL as identifier for the credential cfg
     no_proto_url='{}{}'.format(
         parsed_url.netloc, parsed_url.path).replace(' ', ''),

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -167,7 +167,7 @@ class Update(Interface):
                 str(table), '{url}', filenameformat,
                 ifexists=ifexists,
                 save=False,
-                cfg_proc=None if platform.cred['anonymous']
+                cfg_proc=None if platform.credential_name == 'anonymous'
                 else 'xnat_dataset',
                 result_renderer='default',
             )


### PR DESCRIPTION
XNAT uses 'ID', but connectomeDB uses 'id'.

This changes makes it possible to generate a file URL table
from the connectomeDB too, but when generating the scans response
for HCP_Retest the server gives a 500 response.

However, I can successfully parse the `MGH_DIFF` dataset with this code!

Ping datalad/datalad-xnat#30

demo:

```sh
% datalad xnat-init --credential connectomedb https://db.humanconnectome.org/ -p MGH_DIFF
% datalad xnat-update --credential connectomedb -s ConnectomeDB_S01343
% datalad status --annex
22 annex'd files (3.3 GB recorded total size)
nothing to save, working tree clean
```