### PR TITLE
BF: Use session.auth as an attribute, do not try to call it as a method

### DIFF
--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -80,7 +80,7 @@ class _XNAT(object):
             cred = dict(anonymous=False,
                         user=auth['user'] or None,
                         password=auth['password'] or None)
-            session.auth(auth['user'], auth['password'])
+            session.auth = (auth['user'], auth['password'])
 
         # now check of auth works (if any is needed)
         # TODO check that we have anonymous OR user/pass


### PR DESCRIPTION
In https://github.com/datalad/datalad-xnat/issues/8#issuecomment-929870134
I reported that an authentication attempt resulted in a TypeError.
I believe this is due to a change that happened in #33, which
implemented session.auth, but tried to call the attribute as a method.
This commit introduces the correct format, I believe.