### PR TITLE
ENH: Return an error result for exceptions during authentication

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -18,6 +18,8 @@ from datalad.interface.base import build_doc
 from datalad.support.constraints import (
     EnsureNone,
 )
+
+from datalad.support.exceptions import CapturedException
 from datalad.support.param import Parameter
 from datalad.utils import (
     quote_cmdlinearg,
@@ -99,7 +101,17 @@ class Init(Interface):
             refds=ds.path,
         )
 
-        platform = _XNAT(url, credential=credential)
+        try:
+            platform = _XNAT(url, credential=credential)
+        except Exception as e:
+            ce = CapturedException(e)
+            yield dict(
+                res,
+                status='error',
+                message=('During authentication the XNAT server sent %s', ce),
+                exception=ce
+            )
+            return
 
         if project is None:
             from datalad.ui import ui


### PR DESCRIPTION
This is based on a suggestion by @mih to improve the error handling when
wrong credentials are passed to fix #8. While this change does not do
any proper error handling so far, it returns an exception raised during
authentication as a proper error.

Here is how it looks like:

```
$ datalad xnat-init https://xnat.kube.fz-juelich.de                                                           1 !
xnat_init(error): . (dataset) [During authentication the XNAT server sent RuntimeError(('Failed to access the XNAT server. Full error:\n%s', HTTPError('401 Client Error:  for url: https://xnat.kube.fz-juelich.de/data/JSESSION')))]
```

I think it would still be good to parse the HTTP response and create some proper error handling