### PR TITLE
Discontinue use of urljoin

### DIFF
--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -65,7 +65,10 @@ def parse_xnat(ds, sub, force, platform, xnat_project):
                     # TODO the file size is at file_rec['Size'], could be used
                     # for progress reporting, maybe
                     filename = file_rec['Name']
-                    url = f"{platform.url}/{file_rec['URI']}"
+                    # URIs should be absolute, but be robust, just in case
+                    url = f"{platform.url}{file_rec['URI']}" \
+                        if file_rec['URI'][0] == '/' \
+                        else f"{platform.url}/{file_rec['URI']}"
                     # create line for each file with necessary subject info
                     fh.writerow([sub, experiment, scan, filename, url])
 

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -11,7 +11,6 @@
 
 import logging
 import csv
-from urllib.parse import urljoin
 
 lgr = logging.getLogger('datalad.xnat.parse')
 
@@ -66,7 +65,7 @@ def parse_xnat(ds, sub, force, platform, xnat_project):
                     # TODO the file size is at file_rec['Size'], could be used
                     # for progress reporting, maybe
                     filename = file_rec['Name']
-                    url = urljoin(platform.url, file_rec['URI'])
+                    url = f"{platform.url}/{file_rec['URI']}"
                     # create line for each file with necessary subject info
                     fh.writerow([sub, experiment, scan, filename, url])
 


### PR DESCRIPTION
It requires a base url with a trailing slash to do the right thing.
Given all URL suffixes are hand-crafted, we can simply not use it.

Fixes datalad/datalad-xnat#47

```
In [3]: urljoin('https://www.nitrc.org/ir/', 'data/JSESSION')
Out[3]: 'https://www.nitrc.org/ir/data/JSESSION'

In [4]: urljoin('https://www.nitrc.org/ir/', '/data/JSESSION')
Out[4]: 'https://www.nitrc.org/data/JSESSION'

In [5]: urljoin('https://www.nitrc.org/ir', '/data/JSESSION')
Out[5]: 'https://www.nitrc.org/data/JSESSION'

In [6]: urljoin('https://www.nitrc.org/ir', 'data/JSESSION')
Out[6]: 'https://www.nitrc.org/data/JSESSION'
```