### PR TITLE
Improve error handling

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -15,6 +15,7 @@ import logging
 from datalad.interface.base import Interface
 from datalad.interface.utils import eval_results
 from datalad.interface.base import build_doc
+from datalad.interface.results import get_status_dict
 from datalad.support.constraints import (
     EnsureNone,
 )
@@ -25,7 +26,6 @@ from datalad.utils import (
     quote_cmdlinearg,
     with_pathsep,
 )
-
 from datalad.distribution.dataset import (
     datasetmethod,
     EnsureDataset,
@@ -103,13 +103,22 @@ class Init(Interface):
 
         try:
             platform = _XNAT(url, credential=credential)
+        except RuntimeError as e:
+            ce = CapturedException(e)
+            yield get_status_dict(
+                status='error',
+                message=ce.message,
+                exception=ce,
+                **res,
+            )
+            return
         except Exception as e:
             ce = CapturedException(e)
-            yield dict(
-                res,
+            yield get_status_dict(
                 status='error',
                 message=('During authentication the XNAT server sent %s', ce),
-                exception=ce
+                exception=ce,
+                **res,
             )
             return
 


### PR DESCRIPTION
Following up on PR #44, this catches `HTTPError` from authentication request explicitly and tries to give a more meaningful message, instead of something like the rather generic ones coming from the server like "Client Error for url xxx" when providing invalid credentials.


Examples for invalid credentials showing result dict and its rendering:

```
❱ datalad -f json_pp xnat-init https://xnat.kube.fz-juelich.de                                                                                       
{
  "action": "xnat_init",
  "exception": "RuntimeError(Failed to access the XNAT server. Reason: unauthorized)",
  "exception_traceback": "[init.py:__call__:105,platform.py:__init__:104,platform.py:__init__:95,models.py:raise_for_status:953]",
  "message": [
    "%s",
    "Failed to access the XNAT server. Reason: unauthorized"
  ],
  "path": "/tmp/some",
  "refds": "/tmp/some",
  "status": "error",
  "type": "dataset"
}
```

```
❱ datalad xnat-init https://xnat.kube.fz-juelich.de                                                                                                  1 !
xnat_init(error): . (dataset) [Failed to access the XNAT server. Reason: unauthorized]
```
