### PR TITLE
Make xnat-update read the credential label from config if not given

### DIFF
--- a/datalad_xnat/tests/test_xnatcentral.py
+++ b/datalad_xnat/tests/test_xnatcentral.py
@@ -30,8 +30,6 @@ def test_anonymous_access(path):
         credential='anonymous')
     ds.xnat_update(
         subjects='dcmtest1',
-        # TODO `init` should store this info
-        credential='anonymous',
     )
     # we get the project's payload DICOM in the expected location
     assert_in_results(

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -108,6 +108,8 @@ class Update(Interface):
         xnat_url = ds.config.get('{}.url'.format(cfg_section))
         xnat_project = ds.config.get('{}.project'.format(cfg_section))
         file_path = ds.config.get('{}.path'.format(cfg_section))
+        if not credential:
+            credential = ds.config.get('{}.credential-name'.format(cfg_section))
 
         platform = _XNAT(xnat_url, credential=credential)
 


### PR DESCRIPTION
Fixes datalad/datalad-xnat#49