### PR TITLE
We actually depend on datalad 0.15.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.6
 install_requires =
-    datalad >= 0.12.3
+    datalad >= 0.15.0
     requests
 packages = find:
 include_package_data = True


### PR DESCRIPTION
For e.g. CapturedException. Moreover it makes sense to also use
datalad's minimum Python version (3.6).

Fixes datalad/datalad-xnat#67