### PR TITLE
DOC: Provide an initial structure and some base content for user-oriented docs

### DIFF
--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -1,0 +1,23 @@
+Acknowledgments
+===============
+
+DataLad development is being performed as part of a US-German collaboration in
+computational neuroscience (CRCNS) project "DataGit: converging catalogues,
+warehouses, and deployment logistics into a federated 'data distribution'"
+(Halchenko_/Hanke_), co-funded by the US National Science Foundation (`NSF 1912266`_) and the German Federal Ministry of Education and Research (BMBF 01GQ1905).
+Additional support is provided by the German federal state of
+Saxony-Anhalt and the European Regional Development
+Fund (ERDF), Project: `Center for Behavioral Brain Sciences`_, Imaging Platform.
+
+DataLad is built atop the git-annex_ software that is being developed and
+maintained by `Joey Hess`_.
+
+The extension was created during the Juelich Brain Hackathon 2021 and wouldn't have been possible without a `dedicated team of volunteers <https://github.com/datalad/datalad-xnat#contributors->`_.
+
+.. _Halchenko: http://haxbylab.dartmouth.edu/ppl/yarik.html
+.. _Hanke: http://www.psychoinformatics.de
+.. _NSF 1912266: http://www.nsf.gov/awardsearch/showAward?AWD_ID=1912266
+.. _BMBF 01GQ1411: http://www.gesundheitsforschung-bmbf.de/de/2550.php
+.. _Center for Behavioral Brain Sciences: http://cbbs.eu/en/
+.. _git-annex: http://git-annex.branchable.com
+.. _Joey Hess: https://joeyh.name

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,14 @@
+.. _python:
+
+Python API
+==========
+
+``datalad-xnat`` has three main commands that are exposed as functions via ``datalad.api`` and as methods of the ``Dataset`` class: ``xnat_init`` for [COMPLETE ME], ``xnat_update`` [COMPLETE ME], and ``xnat_query`` for [COMPLETE ME].
+Find out more about each command below.
+
+.. currentmodule:: datalad.api
+.. autosummary::
+   :toctree: generated
+
+   xnat_init
+   xnat_update

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -1,0 +1,13 @@
+.. _cmd:
+
+Command line reference
+======================
+
+``datalad-xnat`` has three main commands: ``xnat-init`` for [COMPLETE ME], ``xnat-update`` [COMPLETE ME], and ``xnat-query`` for [COMPLETE ME].
+Find out more about each command below.
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-xnat-init
+   generated/man/datalad-xnat-update

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,7 @@
+.. _contribute:
+
+Contributing
+============
+
+If you have any questions, comments, bug fixes or improvement suggestions, feel free to contact us via our `Github page <https://github.com/datalad/datalad-xnat>`_.
+Before contributing, be sure to read the `contributing guidelines <https://github.com/datalad/datalad-xnat/blob/master/CONTRIBUTING.md>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,39 +1,40 @@
-DataLad XNAT
-************
+.. include:: ./links.inc
+
+DataLad XNAT: Track and retrieve XNAT projects with DataLad
+-----------------------------------------------------------
+
+This `DataLad extension <handbook.datalad.org/en/latest/r.html?extensions>`_ enables DataLad_ to work with XNAT_ servers.
+Use it to [COMPLETE ME]
 
 .. figure:: _static/git-annex-xnat-logo.png
 
 
-This is a template for creating a `DataLad <http://datalad.org>`__ extension
-that equips DataLad with additional functionality.
+The extension was created during the `Juelich Brain Hackathon 2021 <http://www.csn.fz-juelich.de/inmibi2021/brain-hackathon/>`_ and wouldn't have been possible without a `dedicated team of volunteers <https://github.com/datalad/datalad-xnat#contributors->`_.
+If you want to get in touch or on board as well, please see our :ref:`contributing guidelines <contribute>`.
 
 
-API
-===
 
-High-level API commands
------------------------
+Documentation overview
+^^^^^^^^^^^^^^^^^^^^^^
 
-.. currentmodule:: datalad.api
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   xnat_init
-   xnat_update
-
-
-Command line reference
-----------------------
+   intro
+   settingup
+   tutorial
+   contributing
+   acknowledgements
 
 .. toctree::
    :maxdepth: 1
 
-   generated/man/datalad-xnat-init
-   generated/man/datalad-xnat-update
+   cmd
+   api
 
 
 Indices and tables
-==================
+^^^^^^^^^^^^^^^^^^
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,0 +1,26 @@
+.. include:: ./links.inc
+.. _intro:
+
+Introduction
+============
+
+XNAT
+----
+
+[COMPLETE ME] What is XNAT
+
+
+Goal of the extension
+---------------------
+
+[COMPLETE ME] What did we set out to do?
+
+What can I use this extension for?
+----------------------------------
+
+[COMPLETE ME] Usecases for the extentions
+
+What can I **not** use this extension for?
+------------------------------------------
+
+[COMPLETE ME] Misconceptions, what can this extension not be used for

--- a/docs/source/links.inc
+++ b/docs/source/links.inc
@@ -1,0 +1,21 @@
+.. This (-*- rst -*-) format file contains commonly used link targets
+   and name substitutions.  It may be included in many files,
+   therefore it should only contain link targets and name
+   substitutions.  Try grepping for "^\.\. _" to find plausible
+   candidates for this list.
+
+.. NOTE: reST targets are
+   __not_case_sensitive__, so only one target definition is needed for
+   nipy, NIPY, Nipy, etc...
+
+
+.. _DataLad: https://www.datalad.org
+.. _DataLad Handbook: http://handbook.datalad.org/en/latest/
+.. _GitHub: https://www.github.com/
+.. _git-annex: git-annex.branchable.com/
+.. _git: git-scm.com/
+.. _XNAT: https://www.xnat.org/
+.. _pip: https://pypi.org/project/pip/
+.. _Python: https://www.python.org/
+.. _Special Remote: https://git-annex.branchable.com/special_remotes/
+.. _Special Remotes: https://git-annex.branchable.com/special_remotes/

--- a/docs/source/settingup.rst
+++ b/docs/source/settingup.rst
@@ -1,0 +1,50 @@
+.. include:: ./links.inc
+
+.. _install:
+
+Quickstart
+==========
+
+Requirements
+^^^^^^^^^^^^
+
+DataLad and ``datalad-xnat`` are available for all major operating systems (Linux, MacOS, Windows 10 [#f1]_).
+The relevant requirements are listed below.
+
+   An XNAT_ account with appropriate permissions
+       You need access to an XNAT_ server to able to interact with it, and appropriate permissions to access the projects you are interested in.
+       Keep your XNAT_ instance's URL and your user name and password to your account close by.
+
+   DataLad
+       If you don't have DataLad_ and its underlying tools (`git`_, `git-annex`_) installed yet, please follow the instructions from `the datalad handbook <http://handbook.datalad.org/en/latest/intro/installation.html>`_.
+
+
+Installation
+^^^^^^^^^^^^
+
+``datalad-xnat`` is a Python package available on `pypi <https://pypi.org/project/datalad-xnat/>`_ and installable via pip_.
+
+.. code-block:: bash
+
+   # create and enter a new virtual environment (optional)
+   $ virtualenv --python=python3 ~/env/dl-xnat
+   $ . ~/env/dl-xnat/bin/activate
+   # install from PyPi
+   $ pip install datalad-xnat
+
+Getting started
+^^^^^^^^^^^^^^^
+
+Here's the gist of some of this extension's functionality.
+Checkout the :ref:`Tutorial` for more detailed demonstrations.
+
+[COMPLETE ME] Add a quick walk-through
+
+
+.. admonition:: HELP! I'm new to this!
+
+   If you are confused about the words DataLad dataset, sibling, or dataset publishing,  please head over to the `DataLad Handbook`_ for an introduction to DataLad.
+
+.. rubric:: Footnotes
+
+.. [#f1] While installable for Windows 10, the extension may not be able to perform all functionality documented here. Please get in touch if you are familiar with Windows `to help us fix bugs <https://github.com/datalad/datalad-osf/issues?q=is%3Aissue+is%3Aopen+windows>`_.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,0 +1,10 @@
+.. _tutorial:
+
+Tutorial
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   tutorial/authentication
+   tutorial/tracking_a_project

--- a/docs/source/tutorial/authentication.rst
+++ b/docs/source/tutorial/authentication.rst
@@ -1,0 +1,4 @@
+.. _authentication:
+
+Authentication
+==============

--- a/docs/source/tutorial/tracking_a_project.rst
+++ b/docs/source/tutorial/tracking_a_project.rst
@@ -1,0 +1,4 @@
+.. _trackproject:
+
+Tracking a project
+==================


### PR DESCRIPTION
This paves the way towards user-oriented documentation by supplying a base structure to the documentation.

I have added base content, such as acknowledgements and a bit of structure over various sections types, from the datalad-osf docs. The PR can be merged as is, and sections marked with ``[COMPLETE ME]`` can be filled in by everyone who wishes to make a contribution to the docs.

Fixes #88