### PR TITLE
Use tempfiles for the addurls file tables

### DIFF
--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -175,6 +175,7 @@ class Update(Interface):
                 # make sure the table content is on disk for addurls
                 # to read
                 addurls_table.flush()
+                addurls_table.close()
 
                 # add file urls for subject
                 lgr.info('Downloading files for subject %s', sub)


### PR DESCRIPTION
This avoids cleanup procedures. Fixes datalad/datalad-xnat#51