### PR TITLE
ENH: Add a logging info on starting the authentication process

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -149,6 +149,9 @@ class Init(Interface):
 
         if project is None:
             from datalad.ui import ui
+            lgr.info('Querying %s for projects available to user %s', url,
+                     'anonymous' if platform.credential_name == 'anonymous'
+                     else platform.authenticated_user)
             projects = platform.get_project_ids()
             ui.message(
                 'No project name specified. The following projects are '

--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -85,7 +85,6 @@ class _XNAT(object):
             auth = None
         else:
             try:
-                lgr.info('Authenticating to %s', url)
                 auth = UserPassword(
                     credential,
                     url=f'{url}/app/template/Register.vm',

--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -85,6 +85,7 @@ class _XNAT(object):
             auth = None
         else:
             try:
+                lgr.info('Authenticating to %s', url)
                 auth = UserPassword(
                     credential,
                     url=f'{url}/app/template/Register.vm',


### PR DESCRIPTION
My rational to add this is UX-based: When running "datalad xnat-init"
it can take a while for the command to finish the query. Without any
change to the log level, there is nothing that the user is seeing -
the command just sits there and does not return until the query is
finished. Notifying the user about the process of authentication is
a quick feedback that there indeed is something happening.

Here's a gif before and after the change:
![ux](https://user-images.githubusercontent.com/29738718/135414786-40337c73-1a48-4643-910b-e5d2113085da.gif)
