### PR TITLE
Make default `query_files` result rendering more useful

### DIFF
--- a/datalad_xnat/query_files.py
+++ b/datalad_xnat/query_files.py
@@ -175,7 +175,14 @@ def query_files(platform, experiment=None, project=None, subject=None):
             for ik, ek in _import_experiment_props.items():
                 if ik in er:
                     fr[ek] = er[ik]
-            yield dict(res,
-                       status='ok',
-                       type='file',
-                       **fr)
+            yield dict(
+                res,
+                status='ok',
+                type='file',
+                # give artificial internal XNAT path, matches API,
+                # improves comprehension
+                path=f"{fr['experiment_id']}/{fr['scan_id']}/{fr['name']}",
+                # include collection info (i.e. resource)
+                message=fr.get('collection'),
+                **fr
+            )


### PR DESCRIPTION
Now

```
% datalad xnat-query-files --credential anonymous https://www.nitrc.org/ir --experiment NITRC_IR_E07478
xnat_query(ok): NITRC_IR_E07478/T1/highres001.nii.gz (file) [NIfTI]
xnat_query(ok): NITRC_IR_E07478/T1/highres001_defacemask.nii.gz (file) [NIfTI]
xnat_query(ok): NITRC_IR_E07478/T1/qc.gif (file) [SNAPSHOTS]
xnat_query(ok): NITRC_IR_E07478/T1/highres001_dicominfo.txt (file) [Text]
...
```