### PR TITLE
Add possibility to constrain an update by a collection set

### DIFF
--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -17,7 +17,7 @@ from datalad_xnat.query_files import query_files
 lgr = logging.getLogger('datalad.xnat.parse')
 
 
-def parse_xnat(outfile, sub, force, platform, xnat_project):
+def parse_xnat(outfile, sub, force, platform, xnat_project, collections=None):
     """Lookup specified subject for configured XNAT project and build csv table.
 
     Parameters
@@ -31,6 +31,9 @@ def parse_xnat(outfile, sub, force, platform, xnat_project):
     platform: str
         XNAT instance
     xnat_project: str
+    collections : list
+        If given, a list of collection/resource labels to limit the results
+        to.
     """
     # create csv table containing subject info & file urls
     table_header = ['subject', 'session', 'scan', 'filename', 'url']
@@ -40,6 +43,9 @@ def parse_xnat(outfile, sub, force, platform, xnat_project):
     fh.writerow(table_header)
     lgr.info('Querying info for subject %s', sub)
     for fr in query_files(platform, project=xnat_project, subject=sub):
+        if collections and fr.get('collection') not in collections:
+            lgr.debug('File excluded by collection selection')
+            continue
         # communicate the query (makes outside error control possible)
         yield fr
         # TODO the file size is at file_rec['Size'], could be used

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -87,6 +87,10 @@ class Update(Interface):
             doc="""force (re-)building the addurl tables""",
             action='store_true'),
         jobs=jobs_opt,
+        collection=Parameter(
+            args=("--collection",),
+            action='append',
+            doc="""collection/resource to limit the update to"""),
         **_XNAT.cmd_params
     )
 
@@ -99,6 +103,7 @@ class Update(Interface):
                  ifexists=None,
                  reckless=None,
                  force=False,
+                 collection=None,
                  jobs='auto'):
 
         ds = require_dataset(
@@ -192,6 +197,8 @@ class Update(Interface):
                         force=force,
                         platform=platform,
                         xnat_project=xnat_project,
+                        collections=ensure_list(collection)
+                        if collection else None,
                     )
 
                 # add file urls for subject


### PR DESCRIPTION
```
% datalad xnat-init --credential anonymous --project studyforrest_rev003 https://www.nitrc.org/ir
% datalad xnat-update -s NITRC_IR_S03684 --collection MAT
```

Will only download files in the "MAT" resource/collection.

Multiple collections can be given.