### PR TITLE
TST: Add test for _XNAT

### DIFF
--- a/datalad_xnat/tests/test_xnatcentral.py
+++ b/datalad_xnat/tests/test_xnatcentral.py
@@ -15,31 +15,96 @@ from datalad.api import (
 )
 
 from datalad.tests.utils import (
+    assert_equal,
+    assert_in,
     assert_in_results,
+    assert_raises,
     with_tempfile,
 )
 
+from ..platform import (
+    _XNAT,
+    XNATRequestError,
+)
+
+
+# The following constants define what to test w/ or against wrt to xnatcentral
+# Idea: 1. Changes would be easy to apply to all tests
+#       2. May turn into more generic tests that can be used with different
+#          targets
+XNAT_URL = "https://central.xnat.org"
+XNAT_CREDENTIAL = "anonymous"
+NON_EXISTENT_PROJECT = NON_EXISTENT_SUBJECT = NON_EXISTENT_EXPERIMENT = \
+    "IDONOTEXIST_used_in_datalad-xnat_CI"
+PROJECT = "Sample_DICOM"
+SUBJECT = "CENTRAL_S01894"
+N_SUBJECTS = 2
+EXPERIMENT = "CENTRAL_E03907"
+SCAN = "2"
+
+
+def test_anonymous_access_platform():
+    # test platform object w/ anonymous access to xnatcentral
+
+    platform = _XNAT(XNAT_URL, credential=XNAT_CREDENTIAL)
+
+    # test project info functions
+    project_ids = platform.get_project_ids()
+    assert_in(PROJECT, project_ids)
+    assert_equal(set(project_ids),
+                 set([p['ID'] for p in platform.get_projects()]))
+
+    # test subject info functions
+    assert_raises(XNATRequestError, platform.get_nsubjs,
+                  NON_EXISTENT_PROJECT)
+    assert_raises(XNATRequestError, platform.get_subject_ids,
+                  NON_EXISTENT_PROJECT)
+
+    assert_equal(N_SUBJECTS, platform.get_nsubjs(PROJECT))
+    subjects = platform.get_subject_ids(PROJECT)
+    assert_equal(N_SUBJECTS, len(subjects))
+    assert_in(SUBJECT, subjects)
+
+    # test experiment info functions
+    assert_equal([],
+                 platform.get_experiment_ids(project=NON_EXISTENT_PROJECT,
+                                             subject=NON_EXISTENT_SUBJECT))
+
+    experiments = platform.get_experiment_ids(project=PROJECT, subject=SUBJECT)
+    assert_equal([EXPERIMENT], experiments)
+    assert_equal([EXPERIMENT],
+                 [e['ID'] for e in platform.get_experiments(project=PROJECT,
+                                                            subject=SUBJECT)]
+                 )
+
+    # test scan info functions
+    assert_equal([SCAN], platform.get_scan_ids(EXPERIMENT))
+    assert_raises(XNATRequestError,
+                  platform.get_scan_ids, NON_EXISTENT_EXPERIMENT)
+
 
 @with_tempfile
-def test_anonymous_access(path):
+def test_anonymous_access_api(path):
+    # test command usage w/ anonymous access to xnatcentral
+
     ds = Dataset(path).create()
     assert_in_results(
         ds.xnat_init(
-            'https://central.xnat.org',
-            project='IDONOTEXIST_used_in_datalad-xnat_CI',
-            credential='anonymous',
+            XNAT_URL,
+            project=NON_EXISTENT_PROJECT,
+            credential=XNAT_CREDENTIAL,
             on_failure='ignore'),
         status='error',
         action='xnat_init')
     # minimal demo dataset (pulls .5MB from xnat central)
     ds.xnat_init(
-        'https://central.xnat.org',
-        project='Sample_DICOM',
+        XNAT_URL,
+        project=PROJECT,
         path='{subject}//{session}/{scan}/',
-        credential='anonymous')
+        credential=XNAT_CREDENTIAL)
     ds.xnat_update(
         # must be a subject's accession ID
-        subjects='CENTRAL_S01894',
+        subjects=SUBJECT,
         jobs=2,
     )
     # we get the project's payload DICOM in the expected location
@@ -47,7 +112,7 @@ def test_anonymous_access(path):
         ds.status(annex='availability', recursive=True),
         key='MD5E-s533936--b402d6341f5894c63c991c6361ad14ff.dcm',
         has_content=True,
-        path=str(ds.pathobj / 'CENTRAL_S01894' / 'CENTRAL_E03907' / '2' /
+        path=str(ds.pathobj / SUBJECT / EXPERIMENT / SCAN /
                  'dcmtest1.MR.Sample_DICOM.2.1.20010108.120022.1azj8tu.dcm'),
         state='clean',
         # this seems like a bug, in subdatasets type='symlink'...


### PR DESCRIPTION
Add a couple of assertions on the level of the `_XNAT` class against
XNAT central. This should allow to test some low-level behavior more
easily than going through the command-level functions.

Also introduces constants to be used w/ other tests against XNAT
central, which should make it easier to get to more flexible unittests
that may eventually be used against different target instances.