### PR TITLE
Rough outline of API changes

### DIFF
--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -137,7 +137,7 @@ class Init(Interface):
         )
 
         # check if dataset already initialized
-        if 'datalad.xnat.default.url' in ds.config:
+        if not force and 'datalad.xnat.default.url' in ds.config:
             yield dict(
                 res,
                 status='error',

--- a/datalad_xnat/init.py
+++ b/datalad_xnat/init.py
@@ -30,6 +30,7 @@ from datalad.distribution.dataset import (
     EnsureDataset,
     require_dataset,
 )
+from datalad.ui import ui
 from .platform import (
     _XNAT,
     XNATRequestError
@@ -80,14 +81,11 @@ class Init(Interface):
             args=("url",),
             doc="""XNAT instance URL""",
         ),
-        project=Parameter(
-            args=("-p", "--project",),
-            doc="""name of an XNAT project to track""",
-        ),
-        path=Parameter(
-            args=("-O", "--path",),
+        pathfmt=Parameter(
+            args=("-F", "--pathfmt",),
             doc="""Specify the directory structure for the downloaded files, and
-            if/where a subdataset should be created.
+            if/where a subdataset should be created. The format string must use
+            POSIX notation and must end with a slash ('/').
             To include the subject, session, or scan values, use the following
             format: {subject}/{session}/{scan}/
             To insert a subdataset at a specific directory level use '//':
@@ -97,6 +95,11 @@ class Init(Interface):
             args=("-f", "--force",),
             doc="""force (re-)initialization""",
             action='store_true'),
+        interactive=Parameter(
+            args=("--interactive",),
+            doc="""enables interactive configuration based on XNAT queries.
+            Default: enabled in interactive sessions.""",
+            action='store_true'),
         **_XNAT.cmd_params
     )
 
@@ -104,18 +107,25 @@ class Init(Interface):
     @datasetmethod(name='xnat_init')
     @eval_results
     def __call__(url,
-                 path="{subject}/{session}/{scan}/",
+                 pathfmt="{subject}/{session}/{scan}/",
                  project=None,
-                 force=False,
+                 subject=None,
+                 experiment=None,
+                 collection=None,
                  credential=None,
+                 force=False,
+                 interactive=None,
                  dataset=None):
+
+        if not pathfmt[-1] == '/':
+            raise ValueError(
+                'Path format specification must end with a slash character')
+
+        if interactive is None:
+            interactive = ui.is_interactive
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='initialization')
-
-        # TODO needs a better solution, with_pathsep adds a platform pathsep
-        # and ruins everything on windows
-        #path = with_pathsep(path)
 
         # prep for yield
         res = dict(
@@ -125,6 +135,16 @@ class Init(Interface):
             logger=lgr,
             refds=ds.path,
         )
+
+        # check if dataset already initialized
+        if 'datalad.xnat.default.url' in ds.config:
+            yield dict(
+                res,
+                status='error',
+                message='Dataset found already initialized, '
+                        'use `force` to reinitialize',
+            )
+            return
 
         try:
             platform = _XNAT(url, credential=credential)
@@ -147,55 +167,29 @@ class Init(Interface):
             )
             return
 
-        if project is None:
-            from datalad.ui import ui
-            lgr.info('Querying %s for projects available to user %s', url,
-                     'anonymous' if platform.credential_name == 'anonymous'
-                     else platform.authenticated_user)
-            projects = platform.get_project_ids()
-            ui.message(
-                'No project name specified. The following projects are '
-                'available on {} for user {}:'.format(
-                    url,
-                    'anonymous' if platform.credential_name == 'anonymous'
-                    else platform.authenticated_user))
-            for p in sorted(projects):
-                # list and prep for C&P
-                # TODO multi-column formatting?
-                ui.message("  {}".format(quote_cmdlinearg(p)))
-            return
+        if interactive:
+            # makes queries and let a user pick values
+            if project is None:
+                pass
+            if subject is None:
+                pass
+            if experiment is None:
+                pass
+            if collection is None:
+                pass
+        # at this point, any None value of project, subject, experiment,
+        # collection means: do not limit -- take all
 
-        # query the specified project to make sure it exists and is accessible
-        try:
-            # TODO for big projects this may not be the cheapest possible query
-            # that ensures existence of the project
-            nsubj = platform.get_nsubjs(project)
-        except Exception as e:
-            yield dict(
-                res,
-                status='error',
-                message=(
-                    'Failed to obtain information on project %s from XNAT. '
-                    'Full error:\n%s',
-                    project, e),
-            )
-            return
-
-        lgr.info('XNAT reports %i subjects currently on-record for project %s',
-                 nsubj, project)
-
-        # check if dataset already initialized
-        auth_dir = ds.pathobj / '.datalad' / 'providers'
-        if auth_dir.exists() and not force:
-            yield dict(
-                res,
-                status='error',
-                message='Dataset found already initialized, '
-                        'use `force` to reinitialize',
-            )
-            return
-
-        _cfg_dataset(ds, url, project, path, platform.credential_name)
+        _cfg_dataset(
+            ds,
+            url,
+            project,
+            subject,
+            experiment,
+            collection,
+            pathfmt,
+            platform.credential_name,
+        )
 
         if not platform.credential_name == 'anonymous':
             # Configure XNAT access authentication
@@ -208,19 +202,28 @@ class Init(Interface):
         return
 
 
-def _cfg_dataset(ds, url, project, path_spec, credential_name):
+def _cfg_dataset(ds, url, project, subject, experiment, collection,
+                 pathfmt, credential_name):
     config = ds.config
     # put essential configuration into the dataset
     # TODO https://github.com/datalad/datalad-xnat/issues/42
     for k, v in (('url', url),
                  ('project', project),
-                 ('path', path_spec),
+                 ('subject', subject),
+                 ('experiment', experiment),
+                 ('collection', collection),
+                 ('pathfmt', pathfmt),
                  ('credential-name', credential_name)):
-        config.set(
-            f'datalad.xnat.default.{k}',
-            v,
-            where='dataset',
-            reload=False)
+        cfgvar = f'datalad.xnat.default.{k}'
+        if v is None:
+            if cfgvar in config:
+                config.unset(cfgvar, where='dataset', reload=False)
+        else:
+            config.set(
+                cfgvar,
+                ' '.join(v) if isinstance(v, list) else v,
+                where='dataset',
+                reload=False)
 
     ds.save(
         path=ds.pathobj / '.datalad' / 'config',

--- a/datalad_xnat/parser.py
+++ b/datalad_xnat/parser.py
@@ -17,20 +17,22 @@ from datalad_xnat.query_files import query_files
 lgr = logging.getLogger('datalad.xnat.parse')
 
 
-def parse_xnat(outfile, sub, force, platform, xnat_project, collections=None):
+def parse_xnat(outfile, platform, force=False,
+               project=None, subject=None, experiment=None,
+               collections=None):
     """Lookup specified subject for configured XNAT project and build csv table.
 
     Parameters
     ----------
     outfile: file-like
         Writable file descriptor.
-    sub: str
-        The subject to build a csv table for.
-    force: str
-        Re-build csv table if it already exists.
     platform: str
         XNAT instance
-    xnat_project: str
+    force: str
+        Re-build csv table if it already exists.
+    project: str
+    subject: str
+    experiment: str
     collections : list
         If given, a list of collection/resource labels to limit the results
         to.
@@ -41,8 +43,8 @@ def parse_xnat(outfile, sub, force, platform, xnat_project, collections=None):
     # write subject info to file
     fh = csv.writer(outfile, delimiter=',')
     fh.writerow(table_header)
-    lgr.info('Querying info for subject %s', sub)
-    for fr in query_files(platform, project=xnat_project, subject=sub):
+    for fr in query_files(
+            platform, project=project, subject=subject, experiment=experiment):
         if collections and fr.get('collection') not in collections:
             lgr.debug('File excluded by collection selection')
             continue

--- a/datalad_xnat/platform.py
+++ b/datalad_xnat/platform.py
@@ -71,6 +71,29 @@ class _XNAT(object):
             provided name. If none is provided, the host-part of the XNAT URL
             is used as a name (e.g. 'https://central.xnat.org' ->
             'central.xnat.org')"""),
+        project=Parameter(
+            args=("-p", "--project",),
+            metavar='ID',
+            doc="""accession ID of a single XNAT project to track""",
+        ),
+        subject=Parameter(
+            args=("-s", "--subject",),
+            metavar='ID',
+            doc="""accession ID of a single subject to track""",
+        ),
+        experiment=Parameter(
+            args=("-e", "--experiment",),
+            metavar='ID',
+            doc="""accession ID of a single experiment to track""",
+        ),
+        collection=Parameter(
+            args=("-c", "--collection",),
+            metavar='LABEL',
+            action='append',
+            doc="""limit updates to a specific collection/resource.
+            [CMD: Can be given multiple times CMD][PY: Multiple collections
+            can be specified as a list PY]""",
+        ),
     )
 
     def __init__(self, url, credential):

--- a/datalad_xnat/query_files.py
+++ b/datalad_xnat/query_files.py
@@ -80,18 +80,6 @@ class QueryFiles(Interface):
             args=("url",),
             doc="""XNAT instance URL to query""",
         ),
-        project=Parameter(
-            args=("--project",),
-            doc="""name of an XNAT project to query""",
-        ),
-        experiment=Parameter(
-            args=("--experiment",),
-            doc="""name of an XNAT experiment to query""",
-        ),
-        subject=Parameter(
-            args=("--subject",),
-            doc="""name of an XNAT subject to query""",
-        ),
         **_XNAT.cmd_params
     )
 

--- a/datalad_xnat/tests/test_update.py
+++ b/datalad_xnat/tests/test_update.py
@@ -31,7 +31,10 @@ def fake_init(path):
     _cfg_dataset(
         ds,
         'https://example.com',
-        'dummy',
+        'dummy_project',
+        'dummy_subject',
+        'dummy_experiment',
+        'dummy_collection',
         '{subject}/{session}/{scan}/',
         'nocredential',
     )

--- a/datalad_xnat/tests/test_xnatcentral.py
+++ b/datalad_xnat/tests/test_xnatcentral.py
@@ -88,23 +88,15 @@ def test_anonymous_access_api(path):
     # test command usage w/ anonymous access to xnatcentral
 
     ds = Dataset(path).create()
-    assert_in_results(
-        ds.xnat_init(
-            XNAT_URL,
-            project=NON_EXISTENT_PROJECT,
-            credential=XNAT_CREDENTIAL,
-            on_failure='ignore'),
-        status='error',
-        action='xnat_init')
     # minimal demo dataset (pulls .5MB from xnat central)
     ds.xnat_init(
         XNAT_URL,
         project=PROJECT,
-        path='{subject}//{session}/{scan}/',
+        subject=SUBJECT,
+        pathfmt='{subject}//{session}/{scan}/',
         credential=XNAT_CREDENTIAL)
     ds.xnat_update(
         # must be a subject's accession ID
-        subjects=SUBJECT,
         jobs=2,
     )
     # we get the project's payload DICOM in the expected location

--- a/datalad_xnat/update.py
+++ b/datalad_xnat/update.py
@@ -86,14 +86,16 @@ class Update(Interface):
     @staticmethod
     @datasetmethod(name='xnat_update')
     @eval_results
-    def __call__(subject=None,
-                 credential=None,
-                 dataset=None,
-                 ifexists=None,
-                 reckless=None,
-                 force=False,
+    def __call__(project=None,
+                 subject=None,
+                 experiment=None,
                  collection=None,
-                 jobs='auto'):
+                 credential=None,
+                 force=False,
+                 reckless=None,
+                 ifexists=None,
+                 jobs='auto',
+                 dataset=None):
 
         ds = require_dataset(
             dataset, check_installed=True, purpose='update')
@@ -150,10 +152,11 @@ class Update(Interface):
                         encoding='utf-8') as addurls_table:
                     yield from parse_xnat(
                         addurls_table,
-                        sub=sub,
+                        platform,
                         force=force,
-                        platform=platform,
-                        xnat_project=xnat_project,
+                        project=xnat_project,
+                        subject=sub,
+                        experiment=experiment,
                         collections=ensure_list(collection)
                         if collection else None,
                     )


### PR DESCRIPTION
Also sketches where and how interactive exploration would take place in
`init()`.

Also fixes datalad/datalad-xnat#63 by inspecting the config, instead of
a directory in a dataset.