### PR TITLE
BF: Prevent a key error in case a record does not contain 'digest' section

### DIFF
--- a/datalad_xnat/query_files.py
+++ b/datalad_xnat/query_files.py
@@ -155,7 +155,7 @@ def query_files(platform, experiment=None, project=None, subject=None):
                 if k.lower() in _standardize_file_keys
             }
             # spot check digest
-            digest = fr.pop('digest')
+            digest = fr.pop('digest', '')
             if len(digest) == 32:
                 fr['digest-md5'] = digest
             else:


### PR DESCRIPTION
Should hopefully fix @oportoles observed KeyError in #84.