### PR TITLE
Doc initinternals

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -14,8 +14,14 @@ Glossary
    session
        TODO
 
+   subdataset
+      A DataLad dataset contained within a different DataLad dataset (the parent or DataLad :term:`superdataset`).
+
    subject
        A subject is anyone who participates in a study, and exist within the context of a :term:`project`. Subjects can be registered in multiple :term:`project`\s (e.g., to capture longitudinal data from various studies).
+
+   superdataset
+       A DataLad dataset that contains one or more levels of other DataLad datasets (DataLad :term:`subdataset`\s).
 
    XNAT
       XNAT is an open source imaging informatics platform developed by the Neuroinformatics Research Group at Washington University. It facilitates common management, productivity, and quality assurance tasks for imaging and associated data. Imaging centers can operate an XNAT instance to manage their imaging acquisitions. Typically, they require a user name and password to gain access.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -8,3 +8,4 @@ Tutorial
 
    tutorial/authentication
    tutorial/tracking_a_project
+   tutorial/understanding-init

--- a/docs/source/tutorial/understanding-init.rst
+++ b/docs/source/tutorial/understanding-init.rst
@@ -1,0 +1,79 @@
+.. include:: ../links.inc
+.. _init:
+
+
+Internals: Understanding xnat-init
+==================================
+
+
+Understanding the dataset configurations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One of the main functions of the ``datalad xnat-init`` command is to create a
+dataset-internal configuration with information about the XNAT_ instance, the
+directory structure for downloaded files, and the project to track.
+This configuration is what determines the looks and feel of the final dataset,
+in particular the presence and location of :term:`subdataset`\s, and the imaging
+files you will be able to retrieve afterwards.
+
+The individual components of these configurations are spread over two different
+places in your dataset:
+
+#. a DataLad configuration within ``.datalad/config``
+#. a provider configuration within ``.datalad/providers/``
+
+Both of these configurations are dataset-specific, i.e., configure only the
+behavior of this particular dataset, not other datasets you may have on your
+system.
+
+
+The provider configuration
+--------------------------
+
+The first configuration created by ``datalad xnat-init`` is a so-called "provider configuration".
+Provider configurations are small, plain text files that configure how a specific
+service provider shall be accessed.
+You can find general information on them in `the DataLad handbook <http://handbook.datalad.org/en/latest/beyond_basics/101-146-providers.html>`_.
+
+The provider configuration created by ``datalad xnat-init`` lives in
+``.datalad/providers/xnat-<name>.cfg``, where ``name`` is a placeholder for an
+arbitrary identifier.
+The default name is ``.datalad/providers/xnat-default.cfg``, but in case of datasets
+that track projects from multiple different XNAT instances the identifier allows
+to differentiate between them.
+
+We can take a look into an exemplary configuration file:
+
+.. code-block::
+
+	[provider:xnat-default]
+	url_re = https://xnat.kube.fz-juelich.de/.*
+	credential = xnat.kube.fz-juelich.de
+	authentication_type = http_basic_auth
+
+	[credential:xnat.kube.fz-juelich.de]
+	type = user_password
+
+It specifies the URL to the XNAT instance supplied during ``datalad xnat-init``,
+and determines the credential (such as authentication with a user name and a password)
+and authentication (such `HTTP Basic Authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_)
+type.
+
+The DataLad configuration
+-------------------------
+
+The second configuration created by ``datalad xnat-init`` is a DataLad
+configuration that configures the dataset to use a given provider configuration.
+It is included in the ``.datalad/config file`` and looks like this:
+
+.. code-block:: bash
+
+	[datalad "xnat.default"]
+		url = https://xnat.kube.fz-juelich.de
+		project = phantoms
+		path = {subject}/{session}/{scan}/
+		credential-name = xnat.kube.fz-juelich.de
+
+Note how it identifies a provider configuration via its ``<name>``, and how it
+includes the configuration about which XNAT project to track.
+


### PR DESCRIPTION
First piece of information on some internals on the init command. 
We can merge it as is for now to make faster progress, but later PRs can dissect any information in this file into other files if a different documentation structure makes more sense. Anything about this section could be taken apart or changed in any way necessary.